### PR TITLE
Revert g6 timing fix trio logs

### DIFF
--- a/analysis/analyzeAllPodsInDeviceLog.py
+++ b/analysis/analyzeAllPodsInDeviceLog.py
@@ -21,13 +21,11 @@ def analyzeAllPodsInDeviceLog(fileDict, loopReadDict, outFlag, vFlag):
             fileDict - pass through to next function
             loopReadDict use these keys:
                 logDF complete set of hex pod messages read from report
-                cgmDF complete set of timestamps for CGM values
                 podMgrDict parsed from ## OmnipodPumpManager
             outFlag used to route output (if needed)
             vFlag pass through selection for verbosity
     """
     logDF = loopReadDict['logDF']
-    cgmDF = loopReadDict['cgmDF']
     podMgrDict = loopReadDict['podMgrDict']
 
     podAddresses, breakPoints = findBreakPoints(logDF)
@@ -53,6 +51,6 @@ def analyzeAllPodsInDeviceLog(fileDict, loopReadDict, outFlag, vFlag):
         print(f'  Report on Omnipod from {fileDict["personFile"]}')
         print(f'     Block {idx} of {numChunks}\n')
 
-        analyzePodMessages(fileDict, podFrame, cgmDF, podMgrDict, outFlag, vFlag, idx)
+        analyzePodMessages(fileDict, podFrame, podMgrDict, outFlag, vFlag, idx)
 
     return

--- a/analysis/analyzePodMessages.py
+++ b/analysis/analyzePodMessages.py
@@ -17,7 +17,7 @@ analyzePodMessages
 """
 
 
-def analyzePodMessages(fileDict, podFrame, cgmFrame, podDict, outFlag,
+def analyzePodMessages(fileDict, podFrame, podDict, outFlag,
                        vFlag, chunkNum):
     """
     preprocess podFrame to be from a single pod
@@ -47,14 +47,14 @@ def analyzePodMessages(fileDict, podFrame, cgmFrame, podDict, outFlag,
 
     # add more stuff and return as a DataFrame
     df = generate_table(podFrame, radio_on_time)
- 
+
     # Process df to generate the podState associated with every message
     #   Updates to states occur with pod message (mostly 1d) status
     #     (the state for extended_bolus_active is NOT included (always False))
     #   Includes values for requested bolus and TB
     # Note that .iloc for df and podState are identical
     # Indexing within podState requires .loc
-    podState, faultProcessedMsg = getPodState(df, cgmFrame)
+    podState, faultProcessedMsg = getPodState(df)
 
     # generate a number of useful facts from podState
     # a few values are added / modified later as analysis continues

--- a/analysis/podStateAnalysis.py
+++ b/analysis/podStateAnalysis.py
@@ -71,28 +71,22 @@ def getPodState(frame, cgmFrame):
         # use Pandas to find index for time > timeStamp
         # then extract row before
         #print("Pod timeStamp: ", timeStamp, "lastCgmTime: ", lastCgmTime)
-        # for people who added CGM client, CGM time not reported in log
-        if cgmFrame.empty:
+        tmpDF = cgmFrame[(cgmFrame['time'] > lastCgmTime) & (cgmFrame['time'] < timeStamp)]
+        if ( tmpDF.empty ):
+            #print("Empty data frame")
             cgmTime = lastCgmTime
-            secSinceCgm = 0
         else:
-            tmpDF = cgmFrame[(cgmFrame['time'] > lastCgmTime) & (cgmFrame['time'] < timeStamp)]
-            if ( tmpDF.empty ):
-                #print("Empty data frame")
-                cgmTime = lastCgmTime
-            else:
-                #print("Not empty data frame")
-                #print(tmpDF)
-                xx = tmpDF.iloc[0]['time']
-                #print(xx)
-                cgmTime = pd.Timestamp(xx)
+            #print("Not empty data frame")
+            #print(tmpDF)
+            xx = tmpDF.iloc[0]['time']
+            #print(xx)
+            cgmTime = pd.Timestamp(xx)
 
-            #print("Pod timeStamp: ", timeStamp, "    cgmTime: ", cgmTime)
-            secSinceCgm = (timeStamp - cgmTime).total_seconds()
-            lastCgmTime = cgmTime
-            #print("Pod timeStamp: ", timeStamp, "    cgmTime: ", cgmTime,
-            #      "cgmPodDeltaSec", cgmPodDeltaSec)
-
+        #print("Pod timeStamp: ", timeStamp, "    cgmTime: ", cgmTime)
+        secSinceCgm = (timeStamp - cgmTime).total_seconds()
+        lastCgmTime = cgmTime
+        #print("Pod timeStamp: ", timeStamp, "    cgmTime: ", cgmTime,
+        #      "cgmPodDeltaSec", cgmPodDeltaSec)
         msgType = msgDict['msgType']
         if msgType == '0x0202':
             faultProcessedMsg = getFaultMsg(msgDict)

--- a/analysis/podStateAnalysis.py
+++ b/analysis/podStateAnalysis.py
@@ -7,14 +7,12 @@ import pandas as pd
 # Iterate through all messages and apply parsers to update the podState.
 # If a state is not updated by a given message, the last value for that state
 # is carried forward
-def getPodState(frame, cgmFrame):
+def getPodState(frame):
     """
     Purpose: Evaluate state changes while the pod_progress is in range
 
     Input:
-        frame: DataFrame with all messages for pod
-        cgmFrame: DataFrame with cgm timeStamps for received values
-                  This covers the entire log file, not just current pod
+        frame: DataFrame with all messages
 
     Output:
        podStateFrame       dataframe with pod state extracted from messages
@@ -22,16 +20,9 @@ def getPodState(frame, cgmFrame):
 
     """
     # initialize values for pod states that we will update
-    # add cgm information too
     timeCumSec = -frame.iloc[0]['deltaSec']
     podOnTime = 0
     pod_progress = 0
-    cgmPodDeltaSec = 0
-    # ensure lastCgmTime <= firstPodTime in frame
-    firstPodTime = frame.iloc[0]['time']
-    lastCgmTime = firstPodTime
-    cgmTime = lastCgmTime
-    # print("Initial Pod Time = ", firstPodTime)
     faultProcessedMsg = {}
     insulinDelivered = getUnitsFromPulses(0)
     reqTB = getUnitsFromPulses(0)
@@ -52,8 +43,7 @@ def getPodState(frame, cgmFrame):
                    'msgDict')
 
     colNamesDev = ('logIdx', 'timeStamp', 'deltaSec', 'timeCumSec',
-                   'radioOnCumSec', 'cgmTime', 'secSinceCgm', 
-                   'podOnTime', 'seqNum', 'pod_progress',
+                   'radioOnCumSec', 'podOnTime', 'seqNum', 'pod_progress',
                    'type', 'msgType', 'msgMeaning', 'insulinDelivered',
                    'reqTB', 'reqBolus', 'autoBolus', 'Bolus', 'TB', 'SchBasal',
                    'logAddr', 'address', 'msgDict')
@@ -68,25 +58,7 @@ def getPodState(frame, cgmFrame):
         seqNum = msgDict['seqNum']
         msgMeaning = msgDict['msgMeaning']
         autoBolus = False
-        # use Pandas to find index for time > timeStamp
-        # then extract row before
-        #print("Pod timeStamp: ", timeStamp, "lastCgmTime: ", lastCgmTime)
-        tmpDF = cgmFrame[(cgmFrame['time'] > lastCgmTime) & (cgmFrame['time'] < timeStamp)]
-        if ( tmpDF.empty ):
-            #print("Empty data frame")
-            cgmTime = lastCgmTime
-        else:
-            #print("Not empty data frame")
-            #print(tmpDF)
-            xx = tmpDF.iloc[0]['time']
-            #print(xx)
-            cgmTime = pd.Timestamp(xx)
 
-        #print("Pod timeStamp: ", timeStamp, "    cgmTime: ", cgmTime)
-        secSinceCgm = (timeStamp - cgmTime).total_seconds()
-        lastCgmTime = cgmTime
-        #print("Pod timeStamp: ", timeStamp, "    cgmTime: ", cgmTime,
-        #      "cgmPodDeltaSec", cgmPodDeltaSec)
         msgType = msgDict['msgType']
         if msgType == '0x0202':
             faultProcessedMsg = getFaultMsg(msgDict)
@@ -122,8 +94,7 @@ def getPodState(frame, cgmFrame):
         if row.get('logAddr'):
             colNames = colNamesDev
             list_of_states.append((index, timeStamp, deltaSec, timeCumSec,
-                                  radioOnCumSec, cgmTime, secSinceCgm,
-                                  podOnTime, seqNum,
+                                  radioOnCumSec, podOnTime, seqNum,
                                   pod_progress, row['type'], msgType,
                                   msgMeaning, insulinDelivered, reqTB,
                                   reqBolus, autoBolus, Bolus, TB, schBa,

--- a/main.py
+++ b/main.py
@@ -13,11 +13,9 @@ import os
 def main(fileDict, outFlag, vFlag):
     # read file, create dictionaries and DataFrames
     loopReadDict = loop_read_file(fileDict)
-#    printDict(loopReadDict)
     # loopReadDict has keys:
-    #   fileDict, logDF, cgmDF, podMgrDict, faultInfoDict,
+    #   fileDict, logDF, podMgrDict, faultInfoDict,
     #   loopVersionDict, determBasalDF
-#    thisDF = loopReadDict['cgmDF'])
     fileDict = loopReadDict['fileDict']
     determBasalDF = loopReadDict['determBasalDF']
     # print(loopReadDict)
@@ -76,7 +74,6 @@ def main(fileDict, outFlag, vFlag):
         print('  ----------------------------------------')
         numChunks = 1  # number of pods in log file is always 1
         analyzePodMessages(fileDict, loopReadDict['logDF'],
-                           loopReadDict['cgmDF'],
                            loopReadDict['podMgrDict'],
                            outFlag, vFlag, numChunks)
         if vFlag == 4:

--- a/parsers/messageLogs_functions.py
+++ b/parsers/messageLogs_functions.py
@@ -714,13 +714,10 @@ def extract_messages(recordType, parsed_content):
     # logDF all pod messages in Report (can be across multiple pods)
     logDF = pd.DataFrame(pod_messages)
     cgmDF = pd.DataFrame(cgm_messages)
-    if cgmDF.empty:
-        print("CGM time stamps not included in log")
-    else:
-        cgmDF['time'] = pd.to_datetime(cgmDF['time'])
-        cgmDF['deltaSec'] = (cgmDF['time'] -
-                            cgmDF['time'].shift()
-                            ).dt.seconds.fillna(0).astype(float)
+    cgmDF['time'] = pd.to_datetime(cgmDF['time'])
+    cgmDF['deltaSec'] = (cgmDF['time'] -
+                         cgmDF['time'].shift()
+                         ).dt.seconds.fillna(0).astype(float)
     logDF['time'] = pd.to_datetime(logDF['time'])
     logDF['deltaSec'] = (logDF['time'] -
                          logDF['time'].shift()

--- a/util/report.py
+++ b/util/report.py
@@ -545,9 +545,7 @@ def writeDashStats(outFile, podState, fileDict, logInfoDict, numInitSteps,
         # set up a table format order
         headerString = 'Who, Finish1, Finish2, lastMsgDate, podAddr, ' + \
                        'podHrs, logHrs, #Messages, #Sent, #Recv, ' + \
-                       '#Recv/#Send%,  #Messages/logHrs, ' + \
-                       '#countCmdInsulin, #cgmTiming<10, #10-to-250,  #cgmTiming>250, '  + \
-                       'InsulinDelivered, LotNo, SeqNo, ' + \
+                       '#Recv/#Send%,  InsulinDelivered, LotNo, SeqNo, ' + \
                        'PodFW, BleFW, rawHex(Fault), PDM RefCode, ' + \
                        'filename ' + \
                        'appNameAndVersion, buildDate, ' + \
@@ -569,26 +567,6 @@ def writeDashStats(outFile, podState, fileDict, logInfoDict, numInitSteps,
         bleFw = ''
         lotNo = ''
         seqNo = ''
-    # extract the rows with an insulin bolus or basal command
-    insulinDF = podState[((podState['msgType'] == '0x1a16') | (podState['msgType'] == '0x1a17'))]
-    totalCount = len(insulinDF)
-    # initialize values in case cgm timing is not available
-    cgmString = 'Not a Dexcom - no timing'
-    countLess = 0 # total number > 10 sec and <= 250 since CGM
-    countBetween = 0 # total number > 10 sec and <= 250 since CGM
-    countOver = 0    # total number > 250 sec
-    # examine the state of the cgm to pod time
-    cgmExists = podState[(podState['secSinceCgm'] > 0.0)]
-    if not( cgmExists.empty ):
-        cgmString = "Dexcom available - timing reported"
-        lessDF = insulinDF[((insulinDF['secSinceCgm'] <= 10))]
-        countLess = len(lessDF)
-        betweenDF = insulinDF[((insulinDF['secSinceCgm'] > 10) & (insulinDF['secSinceCgm'] < 250))]
-        countBetween = len(betweenDF)
-        overDF = insulinDF[((insulinDF['secSinceCgm'] >= 250))]
-        countOver = len(overDF)
-    print(cgmString)
-    #print()
     stream_out.write(f"{fileDict['person']},")
     stream_out.write(f"{Finish1},")
     stream_out.write(f"{Finish2},")
@@ -600,11 +578,6 @@ def writeDashStats(outFile, podState, fileDict, logInfoDict, numInitSteps,
     stream_out.write(f"{sendMsgs},")
     stream_out.write(f"{recvMsgs},")
     stream_out.write(f"{100*recvMsgs/sendMsgs:6.0f},")
-    stream_out.write(f"{60.0*logInfoDict['numMsgs']/logInfoDict['podOnTime']:6.1f},")
-    stream_out.write(f"{totalCount:d},")
-    stream_out.write(f"{countLess:d},")
-    stream_out.write(f"{countBetween:d},")
-    stream_out.write(f"{countOver:d},")
     stream_out.write(f"{logInfoDict['insulinDelivered']:6.2f},")
     stream_out.write(f"{lotNo},")
     stream_out.write(f"{seqNo},")

--- a/util/report.py
+++ b/util/report.py
@@ -292,10 +292,10 @@ def writeDescriptivePodStateToOutputFile(outFile, commentString, podState):
     if verboseFlag:
         columnList = ['timeStamp', 'deltaSec', 'timeCumMin', 'seqNum',
                       'address', 'pod_progress', 'type', 'msgType',
-                      'insulinDelivered', 'secSinceCgm', 'msgDict', 'description']
+                      'insulinDelivered', 'msgDict', 'description']
     else:
         columnList = ['timeStamp', 'deltaSec', 'timeCumMin',
-                      'pod_progress', 'msgType', 'insulinDelivered', 'secSinceCgm', 'msgDict',
+                      'pod_progress', 'msgType', 'insulinDelivered', 'msgDict',
                       'description']
     podState = podState[columnList]
     podState.to_csv(outFile)


### PR DESCRIPTION
The addition of G6 timing to Loop Reports broke the ability to read FAX, iAPS and Trio log and log_prev files.
The testing (for Loop) of timing between incoming G6 CGM to next Loop cycle indicated things worked as expected.
Drop this capability as no longer necessary. (Note that G7 and Libre timing was never added to the analysis. 

If we later want to put CGM timing back into the parser - it needs to be done properly and encompass more CGM and log types.

The easiest thing was to just revert two of the commits for CGM timing and move forward.