### PR TITLE
Update for Trio logs to handle swift method for calculating TDD

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,20 +115,20 @@ def main(fileDict, outFlag, vFlag):
                 thisOutFile = generatePlot(outFlag, fileDict, determBasalDF)
                 print(' *** Determine Basal plot created:     ', thisOutFile)
 
+        personDateSuffix = fileDict['person'] + '_' + fileDict['date'] + '.csv'
         # Print csv output for determTddDF_old, determTddDF_tcd
         determTddDF_old = loopReadDict['determTddDF_old']
         if not determTddDF_old.empty:
-            # create a csv file but don't add unique user name/dates to it
-            thisOutFile = outFlag + '/' + 'determTddDF_old_out.csv'
+            # create a csv file with unique user name/dates
+            thisOutFile = outFlag + '/' + 'TDD_old_' + personDateSuffix
             print(" *** determTddDF_old csv file created: ", thisOutFile)
             determTddDF_old.to_csv(thisOutFile)
 
         determTddDF_tcd = loopReadDict['determTddDF_tcd']
         if not determTddDF_tcd.empty:
-            # create a csv file but don't add unique user name/dates to it
-            thisOutFile = outFlag + '/' + 'determTddDF_tcd.csv'
+            # create a csv file with unique user name/dates
+            thisOutFile = outFlag + '/' + 'TDD_tcd' + '_' + personDateSuffix
             print(" *** determTddDF_tcd csv file created: ", thisOutFile)
             determTddDF_tcd.to_csv(thisOutFile)
-
 
     print('------------------------------------------\n')

--- a/main.py
+++ b/main.py
@@ -115,4 +115,20 @@ def main(fileDict, outFlag, vFlag):
                 thisOutFile = generatePlot(outFlag, fileDict, determBasalDF)
                 print(' *** Determine Basal plot created:     ', thisOutFile)
 
+        # Print csv output for determTddDF_old, determTddDF_tcd
+        determTddDF_old = loopReadDict['determTddDF_old']
+        if not determTddDF_old.empty:
+            # create a csv file but don't add unique user name/dates to it
+            thisOutFile = outFlag + '/' + 'determTddDF_old_out.csv'
+            print(" *** determTddDF_old csv file created: ", thisOutFile)
+            determTddDF_old.to_csv(thisOutFile)
+
+        determTddDF_tcd = loopReadDict['determTddDF_tcd']
+        if not determTddDF_tcd.empty:
+            # create a csv file but don't add unique user name/dates to it
+            thisOutFile = outFlag + '/' + 'determTddDF_tcd.csv'
+            print(" *** determTddDF_tcd csv file created: ", thisOutFile)
+            determTddDF_tcd.to_csv(thisOutFile)
+
+
     print('------------------------------------------\n')

--- a/parsers/messageLogs_functions.py
+++ b/parsers/messageLogs_functions.py
@@ -732,6 +732,9 @@ def extract_raw_determTdd(raw_content):
     timestamp_array_old = []
     json_length_array = []
     tdd_array_old = []
+    bolus_array_old = []
+    tb_array_old = []
+    sb_array_old = []
 
     # go through one time for old style TDD information
     while idx < numLines-1:
@@ -766,6 +769,11 @@ def extract_raw_determTdd(raw_content):
                 timestamp_array_old.append(timestamp)
                 json_length_array.append(jdx - idx)
                 tdd_array_old.append(json_dict['TDD'])
+                insulinDict=json_dict['insulin']
+                bolus_array_old.append(insulinDict['bolus'])
+                tb_array_old.append(insulinDict['temp_basal'])
+                sb_array_old.append(insulinDict['scheduled_basal'])
+
             else:
                 if noisy:
                     print("json_dict missing TDD, skipping")
@@ -776,9 +784,13 @@ def extract_raw_determTdd(raw_content):
             thisLine = lines_raw[idx]
 
     # finished the entire lines_raw list, create the data frame
-    d = {'date_time': timestamp_array_old, 'line#_old': line_array_old,
-         'json_length_array': json_length_array,
-         'tdd_array_old': tdd_array_old}
+    d = {'date_time': timestamp_array_old, 
+         'line_in_log': line_array_old,
+         'json_length': json_length_array,
+         'TDD': tdd_array_old,
+         'Bolus': bolus_array_old,
+         'TempBasal': tb_array_old,
+         'SchBasal': sb_array_old}
     determTddDF_old = pd.DataFrame(d)
 
     if noisy:
@@ -801,6 +813,11 @@ def extract_raw_determTdd(raw_content):
     line_array_tcd = []
     timestamp_array_tcd = []
     tdd_array_tcd = []
+    bolus_array_tcd = []
+    tb_array_tcd = []
+    sb_array_tcd = []
+    wt_ave_tcd = []
+    hr_data_tcd = []
     tdd_pattern_tcd = "84 - DEV: TDD Summary:"
 
     # go through one time for old style TDD information
@@ -812,24 +829,41 @@ def extract_raw_determTdd(raw_content):
             timestamp = thisLine[0:10] + ' ' + thisLine[11:19]
             # the next line contains the "- Total: value U" for the TDD
             jdx = idx+1
-            nextLine = lines_raw[idx+1]
-            if nextLine == "":
-                tdd_string = "not found"
-            else:
-                tdd_string = nextLine
-                tmp = tdd_string.replace("- Total: ","")
-                tdd_string = tmp.replace(" U","")
+            tdd_string = lines_raw[idx+1]
+            tmp = tdd_string.replace("- Total: ","")
+            tdd_string = tmp.replace(" U","")
+            bolus_string = lines_raw[idx+2]
+            tmp = bolus_string.replace("- Bolus: ","")
+            bolus_string = tmp.replace(" U",",")
+            tb_string = lines_raw[idx+3]
+            tmp = tb_string.replace("- Temp Basal: ","")
+            tb_string = tmp.replace(" U",",")
+            sb_string = lines_raw[idx+4]
+            tmp = sb_string.replace("- Scheduled Basal: ","")
+            sb_string = tmp.replace(" U","")
+            wt_string = lines_raw[idx+5]
+            tmp = wt_string.replace("- WeightedAverage: ","")
+            wt_string = tmp.replace(" U","")
+            tmp = lines_raw[idx+6]
+            hr_string = tmp.replace("- Hours of Data: ","")
             line_array_tcd.append(idx)
             timestamp_array_tcd.append(timestamp)
             tdd_array_tcd.append(tdd_string)
+            bolus_array_tcd.append(bolus_string)
+            tb_array_tcd.append(tb_string)
+            sb_array_tcd.append(sb_string)
+            wt_ave_tcd.append(wt_string)
+            hr_data_tcd.append(hr_string)
             idx = idx + 6
         else:
             idx = idx+1
             thisLine = lines_raw[idx]
 
     # finished the entire lines_raw list, create the data frame
-    d = {'date_time': timestamp_array_tcd, 'line#_tcd': line_array_tcd,
-         'tdd_array_tcd': tdd_array_tcd}
+    d = {'date_time': timestamp_array_tcd, 'line_in_log': line_array_tcd,
+         'Total': tdd_array_tcd, 'Bolus': bolus_array_tcd,
+         'TempBasal': tb_array_tcd, 'SchBasal': sb_array_tcd,
+         'WtAverage': wt_ave_tcd, 'HrsOfData': hr_data_tcd}
     determTddDF_tcd = pd.DataFrame(d)
 
     if noisy:

--- a/parsers/messageLogs_functions.py
+++ b/parsers/messageLogs_functions.py
@@ -865,6 +865,9 @@ def extract_raw_TDD(raw_content):
     tdd_pattern_tcd_A = "84 - DEV: TDD Summary:"
     tdd_pattern_tcd_B = "111 - DEV: TDD Summary:"
     na_string = "NA"
+    split0 = ": "
+    split1 = " U"
+    split2 = "| "
 
     # go through one time for old style TDD information
     # old hack but it was working so leave it unchanged
@@ -876,31 +879,37 @@ def extract_raw_TDD(raw_content):
             # extract dateTime from beginning of line
             timestamp = thisLine[0:10] + ' ' + thisLine[11:19]
             # the next line contains the "- Total: value U" for the TDD
-            tdd_string = lines_raw[idx+1]
-            tmp = tdd_string.replace("- Total: ","")
-            tdd_string = tmp.replace(" U","")
-            bolus_string = lines_raw[idx+2]
-            tmp = bolus_string.replace("- Bolus: ","")
-            bolus_string = tmp.replace(" U",",")
-            tb_string = lines_raw[idx+3]
-            tmp = tb_string.replace("- Temp Basal: ","")
-            tb_string = tmp.replace(" U",",")
-            sb_string = lines_raw[idx+4]
-            tmp = sb_string.replace("- Scheduled Basal: ","")
-            sb_string = tmp.replace(" U","")
-            wt_string = lines_raw[idx+5]
-            tmp = wt_string.replace("- WeightedAverage: ","")
-            wt_string = tmp.replace(" U","")
-            tmp = lines_raw[idx+6]
-            hr_string = tmp.replace("- Hours of Data: ","")
+            thisString = lines_raw[idx+1]
+            tmp = thisString.split(split0,2)
+            value = tmp[1].split(split1,2)
+            tdd_array_tcd.append(value[0])
+            #
+            thisString = lines_raw[idx+2]
+            tmp = thisString.split(split0,2)
+            value = tmp[1].split(split1,2)
+            bolus_array_tcd.append(value[0])
+            #
+            thisString = lines_raw[idx+3]
+            tmp = thisString.split(split0,2)
+            value = tmp[1].split(split1,2)
+            tb_array_tcd.append(value[0])
+            #
+            thisString = lines_raw[idx+4]
+            tmp = thisString.split(split0,2)
+            value = tmp[1].split(split1,2)
+            sb_array_tcd.append(value[0])
+            #
+            thisString = lines_raw[idx+5]
+            tmp = thisString.split(split0,2)
+            value = tmp[1].split(split1,2)
+            wt_ave_tcd.append(value[0])
+            #
+            thisString = lines_raw[idx+6]
+            value = thisString.split(split0,2)
+            hr_data_tcd.append(value[1])
+            #
             line_array_tcd.append(idx)
             timestamp_array_tcd.append(timestamp)
-            tdd_array_tcd.append(tdd_string)
-            bolus_array_tcd.append(bolus_string)
-            tb_array_tcd.append(tb_string)
-            sb_array_tcd.append(sb_string)
-            wt_ave_tcd.append(wt_string)
-            hr_data_tcd.append(hr_string)
             earliest_date.append(na_string)
             latest_date.append(na_string)
             earliest_type.append(na_string)
@@ -920,24 +929,25 @@ def extract_raw_TDD(raw_content):
             event1 = lines_raw[idx+12]
             line_array_tcd.append(idx)
             timestamp_array_tcd.append(timestamp)
-            value = tdd_string.split("|",3)
-            tdd_array_tcd.append(value[2])
-            value = bolus_string.split("|",3)
-            bolus_array_tcd.append(value[2])
-            value = tb_string.split("|",3)
-            tb_array_tcd.append(value[2])
-            value = sb_string.split("|",3)
-            sb_array_tcd.append(value[2])
-            value = wt_string.split("|",3)
-            wt_ave_tcd.append(value[2])
-            value = hr_string.split(":",2)
+            value = tdd_string.split(split2,3)
+            # remove the two \t after value
+            tdd_array_tcd.append(value[2][:-2])
+            value = bolus_string.split(split2,3)
+            bolus_array_tcd.append(value[2][:-2])
+            value = tb_string.split(split2,3)
+            tb_array_tcd.append(value[2][:-2])
+            value = sb_string.split(split2,3)
+            sb_array_tcd.append(value[2][:-2])
+            value = wt_string.split(split2,3)
+            wt_ave_tcd.append(value[2][:-2])
+            value = hr_string.split(split0,2)
             hr_data_tcd.append(value[1])
             value = event0.split(",",2)
-            type = value[0].split(":",3)
+            type = value[0].split(split0,3)
             earliest_date.append(value[1][-20:-1])
             earliest_type.append(type[2])
             value = event1.split(",",2)
-            type = value[0].split(":",3)
+            type = value[0].split(split0,3)
             latest_date.append(value[1][-20:-1])
             latest_type.append(type[2])
             idx = idx + 15


### PR DESCRIPTION
* This branch can generate individual csv files for the old and new methods for calculating TDD so they can be compared directly
* When parsing output from Trio, iAPS or FAX code, if the information is not there, no csv files are generated
* The Omnipod message parsing continues to work as expected
* Separate analysis is used to compare output from TDD with respect to the delivery as reported by the tdd csv files.